### PR TITLE
Add new 'placeholders' param to flyway_migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vagrant
 .project
+spec/fixtures
+Gemfile.lock

--- a/lib/puppet/parser/functions/flyway_cmd_placeholders.rb
+++ b/lib/puppet/parser/functions/flyway_cmd_placeholders.rb
@@ -1,0 +1,14 @@
+module Puppet::Parser::Functions
+  newfunction(:flyway_cmd_placeholders,:type => :rvalue) do |args|
+    raise Puppet::ParseError, "flyway_cmd_placeholders argument must be a hash" unless args[0].is_a?(Hash)
+
+    placeholders = Array.new
+    args[0].each do |k,v|
+      raise Puppet::ParseError, "flyway_cmd_placeholders hash keys must be strings"   unless k.is_a?(String)
+      raise Puppet::ParseError, "flyway_cmd_placeholders hash values must be strings" unless v.is_a?(String)
+      placeholders << "-placeholders.#{k}='#{v}'"
+    end
+
+    output = placeholders.join(' ')
+  end
+end

--- a/spec/defines/flyway_migration_spec.rb
+++ b/spec/defines/flyway_migration_spec.rb
@@ -9,4 +9,25 @@ describe 'database_schema::flyway_migration' do
     :jdbc_url      => 'jdbc:h2:test'
   }}
   include_examples :compile
+  describe 'placeholders' do
+    context 'when not specified' do
+      it 'should not have placeholders in exec command' do
+        command = catalogue.resource('exec', 'Migration for example db').send(:parameters)[:command]
+        expect(command).to include('flyway -user=\'user\' -password=\'supersecret\' -url=\'jdbc:h2:test\'  -locations=')
+      end
+    end
+    context 'when specified' do
+      let(:params){{
+        :schema_source => '/some/path',
+        :db_username   => 'user',
+        :db_password   => 'supersecret',
+        :jdbc_url      => 'jdbc:h2:test',
+        :placeholders  => {'key1' => 'val1', 'key2' => 'val2'}
+      }}
+      it 'should have placeholders in exec command' do
+        command = catalogue.resource('exec', 'Migration for example db').send(:parameters)[:command]
+        expect(command).to include('flyway -user=\'user\' -password=\'supersecret\' -url=\'jdbc:h2:test\' -placeholders.key1=\'val1\' -placeholders.key2=\'val2\' -locations=')
+      end
+    end
+  end
 end

--- a/spec/defines/flyway_migration_spec.rb
+++ b/spec/defines/flyway_migration_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'database_schema::liquibase_migration' do
+describe 'database_schema::flyway_migration' do
   let(:title){"example db"}
   let(:params){{
-    :changelog_source => '/some/path',
-    :db_username      => 'user',
-    :db_password      => 'supersecret',
-    :jdbc_url         => 'jdbc:h2:test'
+    :schema_source => '/some/path',
+    :db_username   => 'user',
+    :db_password   => 'supersecret',
+    :jdbc_url      => 'jdbc:h2:test'
   }}
   include_examples :compile
 end

--- a/spec/defines/liquibase_migration_spec.rb
+++ b/spec/defines/liquibase_migration_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'database_schema::flyway_migration' do
+describe 'database_schema::liquibase_migration' do
   let(:title){"example db"}
   let(:params){{
-    :schema_source => '/some/path',
-    :db_username   => 'user',
-    :db_password   => 'supersecret',
-    :jdbc_url      => 'jdbc:h2:test'
+    :changelog_source => '/some/path',
+    :db_username      => 'user',
+    :db_password      => 'supersecret',
+    :jdbc_url         => 'jdbc:h2:test'
   }}
   include_examples :compile
 end

--- a/spec/functions/flyway_cmd_placeholders_spec.rb
+++ b/spec/functions/flyway_cmd_placeholders_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
+
+describe 'flyway_cmd_placeholders', :type => :puppet_function do
+  context 'with a valid placeholder hash { \'keyABC\' => \'valueXYZ\' }' do
+    placeholders    = { 'keyABC' => 'valueXYZ' }
+    expected_result = '-placeholders.keyABC=\'valueXYZ\''
+
+    it "should return '#{expected_result}'" do
+      should run.with_params(placeholders).and_return(expected_result)
+    end
+  end
+
+  context 'with a valid placeholder hash { \'keyABC\' => \'valueXYZ\', \'keyFOO\' => \'valueBAR\' }' do
+    placeholders    = { 'keyABC' => 'valueXYZ', 'keyFOO' => 'valueBAR' }
+    expected_result = '-placeholders.keyABC=\'valueXYZ\' -placeholders.keyFOO=\'valueBAR\''
+    it "should return '#{expected_result}'" do
+      should run.with_params(placeholders).and_return(expected_result)
+    end
+  end
+
+  context 'with an empty placeholder hash' do
+    it 'should return an empty string' do
+      should run.with_params({}).and_return('')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,12 @@
 require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
+RSpec.configure do |c|
+  c.default_facts = {
+    :path => '/sbin:/bin:/usr/sbin:/usr/bin:/root/bin'
+  }
+end
+
 shared_examples :compile, :compile => true do
   it { should compile.with_all_deps }
 end


### PR DESCRIPTION
Hi

I've added some new functionality to the flyway_migration defined type to make it possible to use flyway's placeholder replacement feature.

The change adds a new optional 'placeholders' parameter that accepts a hash.  The hash gets converted into a string of `-placeholder.key='value'` command line arguments.

Kind Regards,
Alex
