### PR TITLE
Support Vox Pupuli puppet-archive

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
   "author": "Chris Pitman",
   "dependencies": [
-  	{"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
-  	{"name":"camptocamp/archive","version_requirement":"0.x"},
-  	{"name":"puppetlabs/java","version_requirement":"1.x"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.8.0 < 5.0.0"},
+    {"name":"camptocamp/archive","version_requirement":"0.x"},
+    {"name":"puppetlabs/java","version_requirement":"1.x"}
   ],
   "license": "MIT",
   "name": "cpitman-database_schema",


### PR DESCRIPTION
[camptocamp\archive](https://github.com/camptocamp/puppet-archive) [conflicts](https://github.com/voxpupuli/puppet-archive/issues/165) with [puppet\archive](https://github.com/voxpupuli/puppet-archive).  Many modules have recently switched to using `puppet\archive`.
eg
https://github.com/bfraser/puppet-grafana/pull/85
https://github.com/jenkinsci/puppet-jenkins/pull/516

It is possible to support both by using the `stdlib` function `load_module_metadata`.  This is what I've done here.

I've left the metadata.json alone, but if you are happy to recommend the puppet\archive over the camptocamp version, I could update this too.
