### PR TITLE
Add `baseline_on_migrate` parameter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,4 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')

--- a/manifests/flyway.pp
+++ b/manifests/flyway.pp
@@ -34,7 +34,7 @@ class database_schema::flyway (
     include ::java
     Class['::java'] -> Database_schema::Flyway_migration<||>
   }
-  
+
   archive { "flyway-commandline-${version}":
     ensure   => $ensure,
     url      => $real_source,
@@ -42,6 +42,6 @@ class database_schema::flyway (
     root_dir => "flyway-${version}",
     checksum => false
   }
-  
+
   Class['database_schema::flyway'] -> Database_schema::Flyway_migration<||>
 }

--- a/manifests/liquibase.pp
+++ b/manifests/liquibase.pp
@@ -30,22 +30,22 @@ class database_schema::liquibase (
     undef   => "http://repo1.maven.org/maven2/org/liquibase/liquibase-core/${version}/liquibase-core-${version}-bin.tar.gz",
     default => $source
   }
-  
+
   $dir_ensure = $ensure ? {
     absent  => absent,
     default => directory
   }
-  
+
   if $ensure == present and $manage_java {
     include ::java
     Class['::java'] -> Database_schema::Liquibase_migration<||>
   }
-  
+
   file { "${target_dir}/liquibase":
     ensure => $dir_ensure,
     force  => true
   }
-  
+
   archive { "liquibase-core-${version}-bin":
     ensure   => $ensure,
     url      => $real_source,
@@ -53,6 +53,6 @@ class database_schema::liquibase (
     root_dir => 'liquibase',
     checksum => false
   }
-  
+
   Class['database_schema::liquibase'] -> Database_schema::Liquibase_migration<||>
 }

--- a/manifests/liquibase_migration.pp
+++ b/manifests/liquibase_migration.pp
@@ -40,16 +40,16 @@ define database_schema::liquibase_migration (
     ensure => present,
     source => $changelog_source
   }
-  
+
   $liquibase_base_command = "liquibase --username='${db_username}' --password='${db_password}' --url='${jdbc_url}' --changeLogFile='${changelog_path}'"
-  
+
   if $default_schema == undef {
     $flyway_command = $liquibase_base_command
   }
   else {
     $flyway_command = "${liquibase_base_command} --defaultSchemaNAme='${default_schema}'"
   }
-  
+
   exec { "Migration for ${title}":
     cwd     => $liquibase_path,
     path    => "${liquibase_path}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin",

--- a/spec/defines/flyway_migration_spec.rb
+++ b/spec/defines/flyway_migration_spec.rb
@@ -30,4 +30,38 @@ describe 'database_schema::flyway_migration' do
       end
     end
   end
+  describe 'baseline_on_migrate' do
+    context 'when not specified' do
+      it 'should not have baselineOnMigrate in exec command' do
+        command = catalogue.resource('exec', 'Migration for example db').send(:parameters)[:command]
+        expect(command).not_to include('baselineOnMigrate')
+      end
+    end
+    context 'when true' do
+      let(:params){{
+        :schema_source       => '/some/path',
+        :db_username         => 'user',
+        :db_password         => 'supersecret',
+        :jdbc_url            => 'jdbc:h2:test',
+        :baseline_on_migrate => true,
+      }}
+      it 'should have -baselineOnMigrate=true in exec command' do
+        command = catalogue.resource('exec', 'Migration for example db').send(:parameters)[:command]
+        expect(command).to match('flyway -user=\'user\' -password=\'supersecret\' -url=\'jdbc:h2:test\'  -locations=\'.*\' -baselineOnMigrate=true')
+      end
+    end
+    context 'when true' do
+      let(:params){{
+        :schema_source       => '/some/path',
+        :db_username         => 'user',
+        :db_password         => 'supersecret',
+        :jdbc_url            => 'jdbc:h2:test',
+        :baseline_on_migrate => false,
+      }}
+      it 'should have -baselineOnMigrate=true in exec command' do
+        command = catalogue.resource('exec', 'Migration for example db').send(:parameters)[:command]
+        expect(command).to match('flyway -user=\'user\' -password=\'supersecret\' -url=\'jdbc:h2:test\'  -locations=\'.*\' -baselineOnMigrate=false')
+      end
+    end
+  end
 end


### PR DESCRIPTION
New parameter defaults to `undef` and makes no change to the flyway command
being run.  (This way, Flyway will use whatever its default is, or get the
setting from a flyway.conf config file if present).

Can be set to true/false, in which case `-baselineOnMigrate=true/false`
will be added to the flyway command run.

Also fixed a handful of whitespace errors detected by the recent `puppet-lint`
2.0
