### PR TITLE
Add `timeout` parameter to migration defined types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ group :development, :test do
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
   gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
 end

--- a/manifests/flyway.pp
+++ b/manifests/flyway.pp
@@ -34,7 +34,7 @@ class database_schema::flyway (
     include ::java
     Class['::java'] -> Database_schema::Flyway_migration<||>
   }
-  
+
   archive { "flyway-commandline-${version}":
     ensure   => $ensure,
     url      => $real_source,
@@ -42,6 +42,6 @@ class database_schema::flyway (
     root_dir => "flyway-${version}",
     checksum => false
   }
-  
+
   Class['database_schema::flyway'] -> Database_schema::Flyway_migration<||>
 }

--- a/manifests/liquibase.pp
+++ b/manifests/liquibase.pp
@@ -30,22 +30,22 @@ class database_schema::liquibase (
     undef   => "http://repo1.maven.org/maven2/org/liquibase/liquibase-core/${version}/liquibase-core-${version}-bin.tar.gz",
     default => $source
   }
-  
+
   $dir_ensure = $ensure ? {
     absent  => absent,
     default => directory
   }
-  
+
   if $ensure == present and $manage_java {
     include ::java
     Class['::java'] -> Database_schema::Liquibase_migration<||>
   }
-  
+
   file { "${target_dir}/liquibase":
     ensure => $dir_ensure,
     force  => true
   }
-  
+
   archive { "liquibase-core-${version}-bin":
     ensure   => $ensure,
     url      => $real_source,
@@ -53,6 +53,6 @@ class database_schema::liquibase (
     root_dir => 'liquibase',
     checksum => false
   }
-  
+
   Class['database_schema::liquibase'] -> Database_schema::Liquibase_migration<||>
 }

--- a/manifests/liquibase_migration.pp
+++ b/manifests/liquibase_migration.pp
@@ -19,16 +19,21 @@
 #  Default schema to apply migrations to.
 # [*ensure*]
 #  Only supported value is "latest".
+# [*timeout*]
+#  The maximum time the migration should take in seconds.  This gets passed directly to the migration Exec resource. Defaults to 300.
 #
 define database_schema::liquibase_migration (
   $changelog_source,
   $db_username,
   $db_password,
   $jdbc_url,
-  $liquibase_path      = '/opt/liquibase',
-  $default_schema      = undef,
-  $ensure              = latest
+  $liquibase_path = '/opt/liquibase',
+  $default_schema = undef,
+  $ensure         = latest,
+  $timeout        = 300,
 ){
+  validate_integer($timeout)
+
   $title_hash   = sha1(title)
   $changelog_basename = inline_template('<%= File.basename(@changelog_source) %>')
   $staging_path = "/tmp/liquibase-migration-${title_hash}"
@@ -40,21 +45,22 @@ define database_schema::liquibase_migration (
     ensure => present,
     source => $changelog_source
   }
-  
+
   $liquibase_base_command = "liquibase --username='${db_username}' --password='${db_password}' --url='${jdbc_url}' --changeLogFile='${changelog_path}'"
-  
+
   if $default_schema == undef {
     $flyway_command = $liquibase_base_command
   }
   else {
     $flyway_command = "${liquibase_base_command} --defaultSchemaNAme='${default_schema}'"
   }
-  
+
   exec { "Migration for ${title}":
     cwd     => $liquibase_path,
     path    => "${liquibase_path}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin",
     onlyif  => "${flyway_command} status | grep 'change sets have not been applied'",
     command => "${flyway_command} update",
-    require => File[$changelog_path]
+    timeout => $timeout,
+    require => File[$changelog_path],
   }
 }

--- a/spec/classes/flyway_spec.rb
+++ b/spec/classes/flyway_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
 describe 'database_schema::flyway' do
-  let(:facts){{:operatingsystem => 'RedHat', :osfamily => 'RedHat'}}
+  let(:facts){{:operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '7'}}
   include_examples :compile
 end

--- a/spec/classes/liquibase_spec.rb
+++ b/spec/classes/liquibase_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
 describe 'database_schema::liquibase' do
-  let(:facts){{:operatingsystem => 'RedHat', :osfamily => 'RedHat'}}
+  let(:facts){{:operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '7'}}
   include_examples :compile
 end

--- a/spec/defines/flyway_migration_spec.rb
+++ b/spec/defines/flyway_migration_spec.rb
@@ -30,4 +30,23 @@ describe 'database_schema::flyway_migration' do
       end
     end
   end
+  describe 'timeout' do
+    context 'when not specified' do
+      it 'exec has timeout set to 300 seconds' do
+        is_expected.to contain_exec('Migration for example db').with_timeout(300)
+      end
+    end
+    context 'when specified' do
+      let(:params){{
+        :schema_source => '/some/path',
+        :db_username   => 'user',
+        :db_password   => 'supersecret',
+        :jdbc_url      => 'jdbc:h2:test',
+        :timeout       => 3600
+      }}
+      it 'passes timeout to exec' do
+        is_expected.to contain_exec('Migration for example db').with_timeout(3600)
+      end
+    end
+  end
 end

--- a/spec/defines/liquibase_migration_spec.rb
+++ b/spec/defines/liquibase_migration_spec.rb
@@ -9,4 +9,23 @@ describe 'database_schema::liquibase_migration' do
     :jdbc_url         => 'jdbc:h2:test'
   }}
   include_examples :compile
+  describe 'timeout' do
+    context 'when not specified' do
+      it 'exec has timeout set to 300 seconds' do
+        is_expected.to contain_exec('Migration for example db').with_timeout(300)
+      end
+    end
+    context 'when specified' do
+      let(:params){{
+        :changelog_source => '/some/path',
+        :db_username      => 'user',
+        :db_password      => 'supersecret',
+        :jdbc_url         => 'jdbc:h2:test',
+        :timeout          => 3600
+      }}
+      it 'passes timeout to exec' do
+        is_expected.to contain_exec('Migration for example db').with_timeout(3600)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Expose the `Exec` resource's `timeout` parameter in the flyway and
liquibase migration defined types.  This is better than setting a
`Resource default statement` for Execs where the `Area of effect` can be
problematic. See
https://docs.puppet.com/puppet/latest/reference/lang_defaults.html#area-of-effect

Tests, (and a few minor lint fixups) included.
